### PR TITLE
Messages overhaul + message styling API

### DIFF
--- a/src/main/java/de/blazemcworld/fireflow/code/CodeEditor.java
+++ b/src/main/java/de/blazemcworld/fireflow/code/CodeEditor.java
@@ -16,6 +16,7 @@ import de.blazemcworld.fireflow.code.node.impl.function.FunctionInputsNode;
 import de.blazemcworld.fireflow.code.node.impl.function.FunctionOutputsNode;
 import de.blazemcworld.fireflow.code.type.AllTypes;
 import de.blazemcworld.fireflow.code.widget.*;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import me.xdrop.fuzzywuzzy.FuzzySearch;
 import net.minecraft.entity.Entity;
@@ -727,17 +728,20 @@ public class CodeEditor {
     public void authorizeWeb(String webId, ServerPlayerEntity approver) {
         for (EditOrigin origin : webUsers) {
             if (origin.tryAuth(webId)) {
-                approver.sendMessage(Text.literal("Authorized web to edit code!").formatted(Formatting.GREEN), false);
+                Messages.sendMessage("Authorized the web editor to edit code!", Messages.SUCCESS, approver);
                 for (ServerPlayerEntity player : space.getPlayers()) {
                     if (!space.info.isOwnerOrDeveloper(player.getUuid())) continue;
                     if (player == approver) continue;
-                    player.sendMessage(Text.literal(approver.getGameProfile().getName() + " authorized a web editor request!").formatted(Formatting.YELLOW), false);
+                    Messages.sendMessage(
+                            "<white>" + approver.getGameProfile().getName() + "<default> authorized a web editor request!",
+                            Messages.INFO, player
+                    );
                 }
                 return;
             }
         }
 
-        approver.sendMessage(Text.literal("Could not find web editor with matching id!").formatted(Formatting.RED), false);
+        Messages.sendMessage("Could not find the web editor with the matching id!", Messages.ERROR, approver);
     }
 
     public void close() {

--- a/src/main/java/de/blazemcworld/fireflow/code/web/WebEditor.java
+++ b/src/main/java/de/blazemcworld/fireflow/code/web/WebEditor.java
@@ -9,6 +9,7 @@ import de.blazemcworld.fireflow.code.CodeInteraction;
 import de.blazemcworld.fireflow.code.EditOrigin;
 import de.blazemcworld.fireflow.code.widget.Widget;
 import de.blazemcworld.fireflow.code.widget.WidgetVec;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
 import de.blazemcworld.fireflow.space.SpaceManager;
@@ -154,13 +155,16 @@ public class WebEditor extends Handler.Abstract {
                 editor.enterCode(origin);
                 for (ServerPlayerEntity player : space.getPlayers()) {
                     if (!space.info.isOwnerOrDeveloper(player.getUuid())) continue;
-                    player.sendMessage(Text.literal("Someone opened the web editor for this space.").formatted(Formatting.YELLOW));
-                    player.sendMessage(Text.literal("Click this to allow access, otherwise ignore it.").setStyle(
-                            Style.EMPTY.withClickEvent(new ClickEvent.RunCommand("/authorize-web " + id))
-                                    .withHoverEvent(new HoverEvent.ShowText(Text.literal("Warning: Only do this if you know and trust the person who opened the web editor!")
-                                            .formatted(Formatting.RED)))
-                                    .withFormatting(Formatting.GOLD)
-                    ));
+                    Messages.sendMessage(
+                            "Someone opened the web editor for this space.",
+                            Messages.NOTIFY, player
+                    );
+                    Messages.sendMessage(
+                            "<click:run_command:\"/authorize-web "+id+"\">" +
+                                    "<hover:show_text:\"<default>Warning: Only do this if you know and trust the person who opened the web editor!\">" +
+                                    "Click this message to allow access, otherwise ignore it.",
+                            Messages.FOLLOWUP, player
+                    );
                 }
                 return;
             }

--- a/src/main/java/de/blazemcworld/fireflow/command/AddNodeCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/AddNodeCommand.java
@@ -4,6 +4,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import de.blazemcworld.fireflow.code.EditOrigin;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.util.ModeManager;
 import net.minecraft.server.command.CommandManager;
@@ -28,7 +29,7 @@ public class AddNodeCommand {
                             if (space == null) return Command.SINGLE_SUCCESS;
 
                             if (ModeManager.getFor(player) != ModeManager.Mode.CODE) {
-                                player.sendMessage(Text.literal("You must be in code mode to do that!").formatted(Formatting.RED));
+                                Messages.sendMessage("You must be in code mode to do that!", Messages.ERROR, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 

--- a/src/main/java/de/blazemcworld/fireflow/command/BuildCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/BuildCommand.java
@@ -3,6 +3,7 @@ package de.blazemcworld.fireflow.command;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
 import de.blazemcworld.fireflow.space.SpaceManager;
@@ -23,7 +24,7 @@ public class BuildCommand {
                     if (space == null) return Command.SINGLE_SUCCESS;
 
                     if (!space.info.isOwnerOrBuilder(player.getUuid())) {
-                        player.sendMessage(Text.literal("You are not allowed to do that!").formatted(Formatting.RED));
+                        Messages.sendMessage("You are not allowed to do that!", Messages.ERROR, player);
                         return Command.SINGLE_SUCCESS;
                     }
 
@@ -38,12 +39,12 @@ public class BuildCommand {
                             int id = IntegerArgumentType.getInteger(ctx, "id");
                             SpaceInfo info = SpaceManager.getInfo(id);
                             if (info == null) {
-                                player.sendMessage(Text.literal("Could not find space with id " + id + "!").formatted(Formatting.RED));
+                                Messages.sendMessage("Could not find space with id " + id + "!", Messages.ERROR, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 
                             if (!info.isOwnerOrBuilder(player.getUuid())) {
-                                player.sendMessage(Text.literal("You are not allowed to do that!").formatted(Formatting.RED));
+                                Messages.sendMessage("You are not allowed to do that!", Messages.ERROR, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 

--- a/src/main/java/de/blazemcworld/fireflow/command/CodeCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/CodeCommand.java
@@ -3,6 +3,7 @@ package de.blazemcworld.fireflow.command;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
 import de.blazemcworld.fireflow.space.SpaceManager;
@@ -38,12 +39,12 @@ public class CodeCommand {
                             int id = IntegerArgumentType.getInteger(ctx, "id");
                             SpaceInfo info = SpaceManager.getInfo(id);
                             if (info == null) {
-                                player.sendMessage(Text.literal("Could not find space with id " + id + "!").formatted(Formatting.RED));
+                                Messages.sendMessage("Could not find space with id " + id + "!", Messages.ERROR, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 
                             if (!info.isOwnerOrDeveloper(player.getUuid())) {
-                                player.sendMessage(Text.literal("You are not allowed to do that!").formatted(Formatting.RED));
+                                Messages.sendMessage("You are not allowed to do that!", Messages.ERROR, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 

--- a/src/main/java/de/blazemcworld/fireflow/command/CommandHelper.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/CommandHelper.java
@@ -1,5 +1,6 @@
 package de.blazemcworld.fireflow.command;
 
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceManager;
 import de.blazemcworld.fireflow.util.ModeManager;
@@ -12,7 +13,7 @@ public class CommandHelper {
 
     public static ServerPlayerEntity getPlayer(ServerCommandSource src) {
         if (!src.isExecutedByPlayer()) {
-            src.sendError(Text.literal("You must be a player for this!"));
+            Messages.sendMessage("You must be a player for this!", Messages.ERROR, src);
             return null;
         }
         return src.getPlayer();
@@ -22,7 +23,7 @@ public class CommandHelper {
         if (player == null) return null;
         Space space = SpaceManager.getSpaceForPlayer(player);
         if (space == null) {
-            player.sendMessage(Text.literal("You must be on a space for this!").formatted(Formatting.RED));
+            Messages.sendMessage("You must be on a space for this!", Messages.ERROR, player);
             return null;
         }
         return space;
@@ -31,7 +32,7 @@ public class CommandHelper {
     public static boolean isOwner(ServerPlayerEntity player, Space space) {
         if (space == null || player == null) return false;
         if (!space.info.owner.equals(player.getUuid())) {
-            player.sendMessage(Text.literal("You are not allowed to do that!").formatted(Formatting.RED));
+            Messages.sendMessage("You are not allowed to do that!", Messages.ERROR, player);
             return false;
         }
         return true;
@@ -40,7 +41,7 @@ public class CommandHelper {
     public static boolean isDeveloperOrOwner(ServerPlayerEntity player, Space space) {
         if (space == null || player == null) return false;
         if (!space.info.isOwnerOrDeveloper(player.getUuid())) {
-            player.sendMessage(Text.literal("You are not allowed to do that!").formatted(Formatting.RED));
+            Messages.sendMessage("You are not allowed to do that!", Messages.ERROR, player);
             return false;
         }
         return true;
@@ -49,7 +50,7 @@ public class CommandHelper {
     public static boolean isInCode(ServerPlayerEntity player, Space space) {
         if (space == null || player == null) return false;
         if (ModeManager.getFor(player) != ModeManager.Mode.CODE) {
-            player.sendMessage(Text.literal("You must be in code mode for this!").formatted(Formatting.RED));
+            Messages.sendMessage("You must be in code mode for this!", Messages.ERROR, player);
             return false;
         }
         return true;

--- a/src/main/java/de/blazemcworld/fireflow/command/ContributorCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/ContributorCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import de.blazemcworld.fireflow.FireFlow;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.PlayWorld;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
@@ -42,13 +43,14 @@ public class ContributorCommand {
                             Set<UUID> contributors = getMap.apply(space.info);
 
                             if (contributors.isEmpty()) {
-                                player.sendMessage(Text.literal("There are no " + id + "s!").formatted(Formatting.RED));
+                                Messages.sendMessage("There are no "+ id + "s!", Messages.INFO, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 
-                            player.sendMessage(Text.literal("Space " + id + (contributors.size() == 1 ? "" : "s") + " (" + contributors.size() + "):").formatted(Formatting.AQUA));
+                            Messages.sendMessage("Space " + id + (contributors.size() == 1 ? "" : "s") + " (" + contributors.size() + "):", Messages.INFO, player);
                             for (UUID uuid : contributors) {
-                                resolveName(player.getServerWorld(), uuid, name -> player.sendMessage(Text.literal("- " + name).formatted(Formatting.DARK_AQUA)));
+                                resolveName(player.getServerWorld(), uuid, name -> Messages.sendMessage(
+                                        "<hover:show_text:\"<default>" + uuid.toString() + "\">" + name, Messages.FOLLOWUP, player));
                             }
 
                             return Command.SINGLE_SUCCESS;
@@ -70,23 +72,23 @@ public class ContributorCommand {
                                     String name = ctx.getArgument("name", String.class);
 
                                     if (player.getGameProfile().getName().equalsIgnoreCase(name)) {
-                                        player.sendMessage(Text.literal("You are always a " + id + "!").formatted(Formatting.RED));
+                                        Messages.sendMessage("You are always a " + id + "!", Messages.ERROR, player);
                                         return Command.SINGLE_SUCCESS;
                                     }
 
                                     resolveUUID(player.getServerWorld(), name, uuid -> {
                                         if (uuid == null) {
-                                            player.sendMessage(Text.literal("Could not find player with name " + name).formatted(Formatting.RED));
+                                            Messages.sendMessage("Could not find player with name "+ name, Messages.ERROR, player);
                                             return;
                                         }
 
                                         Set<UUID> contributors = getMap.apply(space.info);
                                         if (contributors.contains(uuid)) {
-                                            player.sendMessage(Text.literal("Player " + name + " is already a " + id).formatted(Formatting.RED));
+                                            Messages.sendMessage("Player " + name + " is already a " + id, Messages.ERROR, player);
                                             return;
                                         }
                                         contributors.add(uuid);
-                                        player.sendMessage(Text.literal("Added " + name + " as " + id).formatted(Formatting.AQUA));
+                                        Messages.sendMessage("Added " + name + " as " + id, Messages.SUCCESS, player);
                                     });
 
                                     return Command.SINGLE_SUCCESS;
@@ -109,19 +111,19 @@ public class ContributorCommand {
                                     String name = ctx.getArgument("name", String.class);
 
                                     if (player.getGameProfile().getName().equalsIgnoreCase(name)) {
-                                        player.sendMessage(Text.literal("You cannot remove yourself!").formatted(Formatting.RED));
+                                        Messages.sendMessage("You cannot remove yourself!", Messages.ERROR, player);
                                         return Command.SINGLE_SUCCESS;
                                     }
 
                                     resolveUUID(player.getServerWorld(), name, uuid -> {
                                         if (uuid == null) {
-                                            player.sendMessage(Text.literal("Could not find player with name " + name).formatted(Formatting.RED));
+                                            Messages.sendMessage("Could not find player with name " + name, Messages.ERROR, player);
                                             return;
                                         }
 
                                         Set<UUID> contributors = getMap.apply(space.info);
                                         if (!contributors.contains(uuid)) {
-                                            player.sendMessage(Text.literal("Player " + name + " is not a " + id).formatted(Formatting.RED));
+                                            Messages.sendMessage("Player " + name + " is not a " + id, Messages.ERROR, player);
                                             return;
                                         }
                                         contributors.remove(uuid);
@@ -137,7 +139,7 @@ public class ContributorCommand {
                                             }
                                         }
 
-                                        player.sendMessage(Text.literal("Removed " + name + " as " + id).formatted(Formatting.AQUA));
+                                        Messages.sendMessage("Removed " + name + " as " + id, Messages.SUCCESS, player);
                                     });
 
                                     return Command.SINGLE_SUCCESS;

--- a/src/main/java/de/blazemcworld/fireflow/command/DummyCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/DummyCommand.java
@@ -3,6 +3,7 @@ package de.blazemcworld.fireflow.command;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.util.DummyPlayer;
 import net.minecraft.server.command.CommandManager;
@@ -24,7 +25,7 @@ public class DummyCommand {
                                     if (!CommandHelper.isDeveloperOrOwner(player, space)) return Command.SINGLE_SUCCESS;
 
                                     if (space.dummyManager.getDummy(id) != null) {
-                                        player.sendMessage(Text.literal("That dummy has already been spawned!").formatted(Formatting.RED));
+                                        Messages.sendMessage("That dummy has already been spawned!", Messages.ERROR, player);
                                         return Command.SINGLE_SUCCESS;
                                     }
 
@@ -43,7 +44,7 @@ public class DummyCommand {
 
                                     DummyPlayer dummy = space.dummyManager.getDummy(id);
                                     if (dummy == null) {
-                                        player.sendMessage(Text.literal("That dummy has not been spawned!").formatted(Formatting.RED));
+                                        Messages.sendMessage("That dummy has not been spawned!", Messages.ERROR, player);
                                         return Command.SINGLE_SUCCESS;
                                     }
 

--- a/src/main/java/de/blazemcworld/fireflow/command/LobbyCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/LobbyCommand.java
@@ -2,6 +2,7 @@ package de.blazemcworld.fireflow.command;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Lobby;
 import de.blazemcworld.fireflow.util.ModeManager;
 import net.minecraft.server.command.CommandManager;
@@ -24,7 +25,7 @@ public class LobbyCommand {
                     if (player == null) return Command.SINGLE_SUCCESS;
 
                     if (player.getServerWorld() == Lobby.world) {
-                        player.sendMessage(Text.literal("You are already in the lobby!").formatted(Formatting.RED));
+                        Messages.sendMessage("You are already in the lobby!", Messages.ERROR, player);
                         return Command.SINGLE_SUCCESS;
                     }
 

--- a/src/main/java/de/blazemcworld/fireflow/command/LocateCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/LocateCommand.java
@@ -5,6 +5,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import de.blazemcworld.fireflow.FireFlow;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceManager;
 import de.blazemcworld.fireflow.util.ModeManager;
@@ -37,7 +38,7 @@ public class LocateCommand {
                         .executes(ctx -> {
                             ServerPlayerEntity target = FireFlow.server.getPlayerManager().getPlayer(StringArgumentType.getString(ctx, "player"));
                             if (target == null) {
-                                ctx.getSource().sendMessage(Text.literal("Player not found!").formatted(Formatting.RED));
+                                Messages.sendMessage("Player not found!", Messages.ERROR, ctx.getSource());
                                 return Command.SINGLE_SUCCESS;
                             }
 
@@ -58,27 +59,31 @@ public class LocateCommand {
 
         switch (mode) {
             case LOBBY: {
-                ctx.getSource().sendMessage(Text.literal(
-                        target.getGameProfile().getName() + " is currently in the lobby."
-                ).formatted(Formatting.GREEN));
+                Messages.sendMessage(
+                        target.getGameProfile().getName() + " is currently in the lobby.",
+                        Messages.INFO, ctx.getSource()
+                );
                 break;
             }
             case PLAY: {
-                ctx.getSource().sendMessage(Text.literal(
-                        target.getGameProfile().getName() + " is currently playing on space #" + space.info.id
-                ).formatted(Formatting.GREEN));
+                Messages.sendMessage(
+                        target.getGameProfile().getName() + " is currently <white>playing<default> on space <white>#" + space.info.id,
+                        Messages.INFO, ctx.getSource()
+                );
                 break;
             }
             case CODE: {
-                ctx.getSource().sendMessage(Text.literal(
-                        target.getGameProfile().getName() + " is currently coding on space #" + space.info.id
-                ).formatted(Formatting.GREEN));
+                Messages.sendMessage(
+                        target.getGameProfile().getName() + " is currently <white>coding<default> on space <white>#" + space.info.id,
+                        Messages.INFO, ctx.getSource()
+                );
                 break;
             }
             case BUILD: {
-                ctx.getSource().sendMessage(Text.literal(
-                        target.getGameProfile().getName() + " is currently building on space #" + space.info.id
-                ).formatted(Formatting.GREEN));
+                Messages.sendMessage(
+                        target.getGameProfile().getName() + " is currently <white>building<default> on space <white>#" + space.info.id,
+                        Messages.INFO, ctx.getSource()
+                );
                 break;
             }
         }

--- a/src/main/java/de/blazemcworld/fireflow/command/MonitorCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/MonitorCommand.java
@@ -2,6 +2,7 @@ package de.blazemcworld.fireflow.command;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceManager;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
@@ -25,7 +26,7 @@ public class MonitorCommand {
 
                     if (player != null && monitors.containsKey(player)) {
                         monitors.remove(player);
-                        player.sendMessage(Text.literal("Stopped monitoring!").formatted(Formatting.AQUA));
+                        Messages.sendMessage("Stopped monitoring!", Messages.INFO, player);
                         return Command.SINGLE_SUCCESS;
                     }
 
@@ -33,7 +34,7 @@ public class MonitorCommand {
                     if (!CommandHelper.isDeveloperOrOwner(player, space)) return Command.SINGLE_SUCCESS;
 
                     monitors.put(player, space);
-                    player.sendMessage(Text.literal("Now monitoring space #" + space.info.id).formatted(Formatting.AQUA));
+                    Messages.sendMessage("Now monitoring space #" + space.info.id, Messages.INFO, player);
                     return Command.SINGLE_SUCCESS;
                 })
         );

--- a/src/main/java/de/blazemcworld/fireflow/command/PlayCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/PlayCommand.java
@@ -3,6 +3,7 @@ package de.blazemcworld.fireflow.command;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
 import de.blazemcworld.fireflow.space.SpaceManager;
@@ -38,7 +39,7 @@ public class PlayCommand {
                             int id = IntegerArgumentType.getInteger(ctx, "id");
                             SpaceInfo info = SpaceManager.getInfo(id);
                             if (info == null) {
-                                player.sendMessage(Text.literal("Could not find space with id " + id + "!").formatted(Formatting.RED));
+                                Messages.sendMessage("Could not find space with id " + id + "!", Messages.ERROR, player);
                                 return Command.SINGLE_SUCCESS;
                             }
 

--- a/src/main/java/de/blazemcworld/fireflow/command/ReloadCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/ReloadCommand.java
@@ -2,6 +2,7 @@ package de.blazemcworld.fireflow.command;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
@@ -19,7 +20,7 @@ public class ReloadCommand {
                     if (!CommandHelper.isDeveloperOrOwner(player, space)) return Command.SINGLE_SUCCESS;
 
                     space.reload();
-                    player.sendMessage(Text.literal("Reloaded space!").formatted(Formatting.AQUA));
+                    Messages.sendMessage("Reloaded space!", Messages.SUCCESS, player);
                     return Command.SINGLE_SUCCESS;
                 })
                 .then(CommandManager.literal("live")
@@ -29,7 +30,7 @@ public class ReloadCommand {
                             if (!CommandHelper.isDeveloperOrOwner(player, space)) return Command.SINGLE_SUCCESS;
 
                             space.evaluator.liveReload();
-                            player.sendMessage(Text.literal("Live reloaded space!").formatted(Formatting.AQUA));
+                            Messages.sendMessage("Live reloaded space!", Messages.SUCCESS, player);
                             return Command.SINGLE_SUCCESS;
                         })
                 )

--- a/src/main/java/de/blazemcworld/fireflow/command/ShowLagCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/ShowLagCommand.java
@@ -2,6 +2,7 @@ package de.blazemcworld.fireflow.command;
 
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
 import de.blazemcworld.fireflow.space.SpaceManager;
@@ -30,20 +31,18 @@ public class ShowLagCommand {
                     }
 
                     if (cpuUsages.isEmpty()) {
-                        ctx.getSource().sendFeedback(() -> Text.literal("All should be good!").formatted(Formatting.GREEN), false);
+                        Messages.sendMessage("All should be good!", Messages.INFO, ctx.getSource());
                         return Command.SINGLE_SUCCESS;
                     }
 
-                    ctx.getSource().sendFeedback(() -> Text.literal("Found " + cpuUsages.size() + " spaces which might be affecting server performance.").formatted(Formatting.DARK_AQUA), false);
-
-                    Style style = Style.EMPTY
-                            .withFormatting(Formatting.DARK_AQUA)
-                            .withHoverEvent(new HoverEvent.ShowText(Text.literal("CPU usage shown in allowance per space.")
-                                    .setStyle(Style.EMPTY.withFormatting(Formatting.GRAY).withItalic(false))));
+                    Messages.sendMessage("Found " + cpuUsages.size() + " spaces which might be affecting server performance.", Messages.INFO, ctx.getSource());
 
                     cpuUsages.sort(Comparator.comparingInt(p -> -p.getRight()));
                     for (Pair<SpaceInfo, Integer> entry : cpuUsages) {
-                        ctx.getSource().sendFeedback(() -> Text.literal("Space #" + entry.getLeft().id + ": " + entry.getRight() + "%").setStyle(style), false);
+                        Messages.sendMessage(
+                                "<hover:show_text:\"<default>CPU usage shown in allowance per space\">Space #" + entry.getLeft().id + ": " + entry.getRight() + "%",
+                                Messages.FOLLOWUP, ctx.getSource()
+                        );
                     }
                     return Command.SINGLE_SUCCESS;
                 }));

--- a/src/main/java/de/blazemcworld/fireflow/command/SpaceCommand.java
+++ b/src/main/java/de/blazemcworld/fireflow/command/SpaceCommand.java
@@ -6,6 +6,7 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.serialization.DataResult;
 import de.blazemcworld.fireflow.inventory.ConfirmationMenu;
+import de.blazemcworld.fireflow.messages.Messages;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceManager;
 import net.minecraft.registry.Registries;
@@ -36,11 +37,16 @@ public class SpaceCommand {
                                     DataResult<Identifier> result = Identifier.validate(StringArgumentType.getString(ctx, "icon"));
                                     if (result.isSuccess() && Registries.ITEM.containsId(result.getOrThrow())) {
                                         space.info.icon = Registries.ITEM.get(result.getOrThrow());
-                                        player.sendMessage(Text.literal("Changed space icon!").formatted(Formatting.AQUA));
+                                        Messages.sendMessage(
+                                                "Changed space icon to <white><lang:"
+                                                        + space.info.icon.getTranslationKey()
+                                                        + "><default>!",
+                                                Messages.SUCCESS, player
+                                        );
                                         return Command.SINGLE_SUCCESS;
                                     }
 
-                                    player.sendMessage(Text.literal("Invalid icon!").formatted(Formatting.RED));
+                                    Messages.sendMessage("Invalid icon!", Messages.INFO, player);
                                     return Command.SINGLE_SUCCESS;
                                 })
                         )
@@ -54,12 +60,15 @@ public class SpaceCommand {
 
                                     String name = StringArgumentType.getString(ctx, "name");
                                     if (name.length() > 256) {
-                                        player.sendMessage(Text.literal("Name too long!").formatted(Formatting.RED));
+                                        Messages.sendMessage("Name too long!", Messages.ERROR, player);
                                         return Command.SINGLE_SUCCESS;
                                     }
                                     space.info.name = name;
 
-                                    player.sendMessage(Text.literal("Changed space name!").formatted(Formatting.AQUA));
+                                    Messages.sendMessage(
+                                            "Changed space name to " + Messages.escapeMiniMessage(name, Messages.SUCCESS) + "!",
+                                            Messages.SUCCESS, player
+                                    );
                                     return Command.SINGLE_SUCCESS;
                                 })
                         )
@@ -72,7 +81,7 @@ public class SpaceCommand {
 
                             ConfirmationMenu.open(player, "Delete this space?", () -> {
                                 SpaceManager.delete(space);
-                                player.sendMessage(Text.literal("Deleted space!").formatted(Formatting.AQUA));
+                                Messages.sendMessage("Deleted space!", Messages.SUCCESS, player);
                             }, null);
 
                             return Command.SINGLE_SUCCESS;

--- a/src/main/java/de/blazemcworld/fireflow/inventory/MySpacesMenu.java
+++ b/src/main/java/de/blazemcworld/fireflow/inventory/MySpacesMenu.java
@@ -1,6 +1,7 @@
 package de.blazemcworld.fireflow.inventory;
 
 import de.blazemcworld.fireflow.code.type.TextType;
+import de.blazemcworld.fireflow.messages.ColourPalette;
 import de.blazemcworld.fireflow.space.Space;
 import de.blazemcworld.fireflow.space.SpaceInfo;
 import de.blazemcworld.fireflow.space.SpaceManager;
@@ -98,7 +99,7 @@ public class MySpacesMenu extends InventoryMenu {
 
     private static ItemStack createSpaceItem() {
         ItemStack item = new ItemStack(Items.GREEN_STAINED_GLASS);
-        item.set(DataComponentTypes.ITEM_NAME, Text.literal("Create Space").formatted(Formatting.GREEN));
+        item.set(DataComponentTypes.ITEM_NAME, Text.literal("Create Space").withColor(ColourPalette.MINT_LIGHT_2.rgb24));
         item.set(DataComponentTypes.LORE, new LoreComponent(List.of(
                 Text.literal("Click to create").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.GRAY)),
                 Text.literal("a new space.").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.GRAY))

--- a/src/main/java/de/blazemcworld/fireflow/messages/ColourPalette.java
+++ b/src/main/java/de/blazemcworld/fireflow/messages/ColourPalette.java
@@ -1,0 +1,252 @@
+
+/*
+  Palette by AlignedCookie88
+  Licensed under CC0 1.0 Universal
+  https://github.com/AlignedCookie88/ColourPalette
+*/
+
+package de.blazemcworld.fireflow.messages;
+
+public class ColourPalette {
+
+    public static final Colour RED_GLOOMY_2 = new Colour(0x880000);
+    public static final Colour RED_GLOOMY = new Colour(0x990000);
+    public static final Colour RED_DARK_3 = new Colour(0xAA0000);
+    public static final Colour RED_DARK_2 = new Colour(0xBB1111);
+    public static final Colour RED_DARK = new Colour(0xCC2222);
+    public static final Colour RED = new Colour(0xDD3333);
+    public static final Colour RED_LIGHT_1 = new Colour(0xEE4444);
+    public static final Colour RED_LIGHT_2 = new Colour(0xFF5555);
+    public static final Colour RED_PASTEL = new Colour(0xFF6666);
+    public static final Colour RED_PASTEL_2 = new Colour(0xFF7777);
+
+    public static final Colour ORANGE_GLOOMY_2 = new Colour(0x882D00);
+    public static final Colour ORANGE_GLOOMY = new Colour(0x993300);
+    public static final Colour ORANGE_DARK_3 = new Colour(0xAA3800);
+    public static final Colour ORANGE_DARK_2 = new Colour(0xBB4911);
+    public static final Colour ORANGE_DARK = new Colour(0xCC5A22);
+    public static final Colour ORANGE = new Colour(0xDD6B33);
+    public static final Colour ORANGE_LIGHT_1 = new Colour(0xEE7C44);
+    public static final Colour ORANGE_LIGHT_2 = new Colour(0xFF8D55);
+    public static final Colour ORANGE_PASTEL = new Colour(0xFF9966);
+    public static final Colour ORANGE_PASTEL_2 = new Colour(0xFFA477);
+
+    public static final Colour MUSTARD_GLOOMY_2 = new Colour(0x885A00);
+    public static final Colour MUSTARD_GLOOMY = new Colour(0x996600);
+    public static final Colour MUSTARD_DARK_3 = new Colour(0xAA7100);
+    public static final Colour MUSTARD_DARK_2 = new Colour(0xBB8211);
+    public static final Colour MUSTARD_DARK = new Colour(0xCC9322);
+    public static final Colour MUSTARD = new Colour(0xDDA433);
+    public static final Colour MUSTARD_LIGHT_1 = new Colour(0xEEB544);
+    public static final Colour MUSTARD_LIGHT_2 = new Colour(0xFFC655);
+    public static final Colour MUSTARD_PASTEL = new Colour(0xFFCC66);
+    public static final Colour MUSTARD_PASTEL_2 = new Colour(0xFFD177);
+
+    public static final Colour YELLOW_GLOOMY_2 = new Colour(0x888800);
+    public static final Colour YELLOW_GLOOMY = new Colour(0x999900);
+    public static final Colour YELLOW_DARK_3 = new Colour(0xAAAA00);
+    public static final Colour YELLOW_DARK_2 = new Colour(0xBBBB11);
+    public static final Colour YELLOW_DARK = new Colour(0xCCCC22);
+    public static final Colour YELLOW = new Colour(0xDDDD33);
+    public static final Colour YELLOW_LIGHT_1 = new Colour(0xEEEE44);
+    public static final Colour YELLOW_LIGHT_2 = new Colour(0xFFFF55);
+    public static final Colour YELLOW_PASTEL = new Colour(0xFFFF66);
+    public static final Colour YELLOW_PASTEL_2 = new Colour(0xFFFF77);
+
+    public static final Colour LIME_GLOOMY_2 = new Colour(0x5A8800);
+    public static final Colour LIME_GLOOMY = new Colour(0x669900);
+    public static final Colour LIME_DARK_3 = new Colour(0x71AA00);
+    public static final Colour LIME_DARK_2 = new Colour(0x82BB11);
+    public static final Colour LIME_DARK = new Colour(0x93CC22);
+    public static final Colour LIME = new Colour(0xA4DD33);
+    public static final Colour LIME_LIGHT_1 = new Colour(0xB5EE44);
+    public static final Colour LIME_LIGHT_2 = new Colour(0xC6FF55);
+    public static final Colour LIME_PASTEL = new Colour(0xCCFF66);
+    public static final Colour LIME_PASTEL_2 = new Colour(0xD1FF77);
+
+    public static final Colour GRASS_GLOOMY_2 = new Colour(0x2D8800);
+    public static final Colour GRASS_GLOOMY = new Colour(0x339900);
+    public static final Colour GRASS_DARK_3 = new Colour(0x38AA00);
+    public static final Colour GRASS_DARK_2 = new Colour(0x49BB11);
+    public static final Colour GRASS_DARK = new Colour(0x5ACC22);
+    public static final Colour GRASS = new Colour(0x6BDD33);
+    public static final Colour GRASS_LIGHT_1 = new Colour(0x7CEE44);
+    public static final Colour GRASS_LIGHT_2 = new Colour(0x8DFF55);
+    public static final Colour GRASS_PASTEL = new Colour(0x99FF66);
+    public static final Colour GRASS_PASTEL_2 = new Colour(0xA4FF77);
+
+    public static final Colour GREEN_GLOOMY_2 = new Colour(0x008800);
+    public static final Colour GREEN_GLOOMY = new Colour(0x009900);
+    public static final Colour GREEN_DARK_3 = new Colour(0x00AA00);
+    public static final Colour GREEN_DARK_2 = new Colour(0x11BB11);
+    public static final Colour GREEN_DARK = new Colour(0x22CC22);
+    public static final Colour GREEN = new Colour(0x33DD33);
+    public static final Colour GREEN_LIGHT_1 = new Colour(0x44EE44);
+    public static final Colour GREEN_LIGHT_2 = new Colour(0x55FF55);
+    public static final Colour GREEN_PASTEL = new Colour(0x66FF66);
+    public static final Colour GREEN_PASTEL_2 = new Colour(0x77FF77);
+
+    public static final Colour MINT_GLOOMY_2 = new Colour(0x00882D);
+    public static final Colour MINT_GLOOMY = new Colour(0x009933);
+    public static final Colour MINT_DARK_3 = new Colour(0x00AA38);
+    public static final Colour MINT_DARK_2 = new Colour(0x11BB49);
+    public static final Colour MINT_DARK = new Colour(0x22CC5A);
+    public static final Colour MINT = new Colour(0x33DD6B);
+    public static final Colour MINT_LIGHT_1 = new Colour(0x44EE7C);
+    public static final Colour MINT_LIGHT_2 = new Colour(0x55FF8D);
+    public static final Colour MINT_PASTEL = new Colour(0x66FF99);
+    public static final Colour MINT_PASTEL_2 = new Colour(0x77FFA4);
+
+    public static final Colour TEAL_GLOOMY_2 = new Colour(0x00885A);
+    public static final Colour TEAL_GLOOMY = new Colour(0x009966);
+    public static final Colour TEAL_DARK_3 = new Colour(0x00AA71);
+    public static final Colour TEAL_DARK_2 = new Colour(0x11BB82);
+    public static final Colour TEAL_DARK = new Colour(0x22CC93);
+    public static final Colour TEAL = new Colour(0x33DDA4);
+    public static final Colour TEAL_LIGHT_1 = new Colour(0x44EEB5);
+    public static final Colour TEAL_LIGHT_2 = new Colour(0x55FFC6);
+    public static final Colour TEAL_PASTEL = new Colour(0x66FFCC);
+    public static final Colour TEAL_PASTEL_2 = new Colour(0x77FFD1);
+
+    public static final Colour AQUA_GLOOMY_2 = new Colour(0x008888);
+    public static final Colour AQUA_GLOOMY = new Colour(0x009999);
+    public static final Colour AQUA_DARK_3 = new Colour(0x00AAAA);
+    public static final Colour AQUA_DARK_2 = new Colour(0x11BBBB);
+    public static final Colour AQUA_DARK = new Colour(0x22CCCC);
+    public static final Colour AQUA = new Colour(0x33DDDD);
+    public static final Colour AQUA_LIGHT_1 = new Colour(0x44EEEE);
+    public static final Colour AQUA_LIGHT_2 = new Colour(0x55FFFF);
+    public static final Colour AQUA_PASTEL = new Colour(0x66FFFF);
+    public static final Colour AQUA_PASTEL_2 = new Colour(0x77FFFF);
+
+    public static final Colour SKY_GLOOMY_2 = new Colour(0x005A88);
+    public static final Colour SKY_GLOOMY = new Colour(0x006699);
+    public static final Colour SKY_DARK_3 = new Colour(0x0071AA);
+    public static final Colour SKY_DARK_2 = new Colour(0x1182BB);
+    public static final Colour SKY_DARK = new Colour(0x2293CC);
+    public static final Colour SKY = new Colour(0x33A4DD);
+    public static final Colour SKY_LIGHT_1 = new Colour(0x44B5EE);
+    public static final Colour SKY_LIGHT_2 = new Colour(0x55C6FF);
+    public static final Colour SKY_PASTEL = new Colour(0x66CCFF);
+    public static final Colour SKY_PASTEL_2 = new Colour(0x77D1FF);
+
+    public static final Colour CORNFLOWER_GLOOMY_2 = new Colour(0x002D88);
+    public static final Colour CORNFLOWER_GLOOMY = new Colour(0x003399);
+    public static final Colour CORNFLOWER_DARK_3 = new Colour(0x0038AA);
+    public static final Colour CORNFLOWER_DARK_2 = new Colour(0x1149BB);
+    public static final Colour CORNFLOWER_DARK = new Colour(0x225ACC);
+    public static final Colour CORNFLOWER = new Colour(0x336BDD);
+    public static final Colour CORNFLOWER_LIGHT_1 = new Colour(0x447CEE);
+    public static final Colour CORNFLOWER_LIGHT_2 = new Colour(0x558DFF);
+    public static final Colour CORNFLOWER_PASTEL = new Colour(0x6699FF);
+    public static final Colour CORNFLOWER_PASTEL_2 = new Colour(0x77A4FF);
+
+    public static final Colour BLUE_GLOOMY_2 = new Colour(0x000088);
+    public static final Colour BLUE_GLOOMY = new Colour(0x000099);
+    public static final Colour BLUE_DARK_3 = new Colour(0x0000AA);
+    public static final Colour BLUE_DARK_2 = new Colour(0x1111BB);
+    public static final Colour BLUE_DARK = new Colour(0x2222CC);
+    public static final Colour BLUE = new Colour(0x3333DD);
+    public static final Colour BLUE_LIGHT_1 = new Colour(0x4444EE);
+    public static final Colour BLUE_LIGHT_2 = new Colour(0x5555FF);
+    public static final Colour BLUE_PASTEL = new Colour(0x6666FF);
+    public static final Colour BLUE_PASTEL_2 = new Colour(0x7777FF);
+
+    public static final Colour VIOLET_GLOOMY_2 = new Colour(0x2D0088);
+    public static final Colour VIOLET_GLOOMY = new Colour(0x330099);
+    public static final Colour VIOLET_DARK_3 = new Colour(0x3800AA);
+    public static final Colour VIOLET_DARK_2 = new Colour(0x4911BB);
+    public static final Colour VIOLET_DARK = new Colour(0x5A22CC);
+    public static final Colour VIOLET = new Colour(0x6B33DD);
+    public static final Colour VIOLET_LIGHT_1 = new Colour(0x7C44EE);
+    public static final Colour VIOLET_LIGHT_2 = new Colour(0x8D55FF);
+    public static final Colour VIOLET_PASTEL = new Colour(0x9966FF);
+    public static final Colour VIOLET_PASTEL_2 = new Colour(0xA477FF);
+
+    public static final Colour ORCHID_GLOOMY_2 = new Colour(0x5A0088);
+    public static final Colour ORCHID_GLOOMY = new Colour(0x660099);
+    public static final Colour ORCHID_DARK_3 = new Colour(0x7100AA);
+    public static final Colour ORCHID_DARK_2 = new Colour(0x8211BB);
+    public static final Colour ORCHID_DARK = new Colour(0x9322CC);
+    public static final Colour ORCHID = new Colour(0xA433DD);
+    public static final Colour ORCHID_LIGHT_1 = new Colour(0xB544EE);
+    public static final Colour ORCHID_LIGHT_2 = new Colour(0xC655FF);
+    public static final Colour ORCHID_PASTEL = new Colour(0xCC66FF);
+    public static final Colour ORCHID_PASTEL_2 = new Colour(0xD177FF);
+
+    public static final Colour PINK_GLOOMY_2 = new Colour(0x880088);
+    public static final Colour PINK_GLOOMY = new Colour(0x990099);
+    public static final Colour PINK_DARK_3 = new Colour(0xAA00AA);
+    public static final Colour PINK_DARK_2 = new Colour(0xBB11BB);
+    public static final Colour PINK_DARK = new Colour(0xCC22CC);
+    public static final Colour PINK = new Colour(0xDD33DD);
+    public static final Colour PINK_LIGHT_1 = new Colour(0xEE44EE);
+    public static final Colour PINK_LIGHT_2 = new Colour(0xFF55FF);
+    public static final Colour PINK_PASTEL = new Colour(0xFF66FF);
+    public static final Colour PINK_PASTEL_2 = new Colour(0xFF77FF);
+
+    public static final Colour MAGENTA_GLOOMY_2 = new Colour(0x88005A);
+    public static final Colour MAGENTA_GLOOMY = new Colour(0x990066);
+    public static final Colour MAGENTA_DARK_3 = new Colour(0xAA0071);
+    public static final Colour MAGENTA_DARK_2 = new Colour(0xBB1182);
+    public static final Colour MAGENTA_DARK = new Colour(0xCC2293);
+    public static final Colour MAGENTA = new Colour(0xDD33A4);
+    public static final Colour MAGENTA_LIGHT_1 = new Colour(0xEE44B5);
+    public static final Colour MAGENTA_LIGHT_2 = new Colour(0xFF55C6);
+    public static final Colour MAGENTA_PASTEL = new Colour(0xFF66CC);
+    public static final Colour MAGENTA_PASTEL_2 = new Colour(0xFF77D1);
+
+    public static final Colour ROSE_GLOOMY_2 = new Colour(0x88002D);
+    public static final Colour ROSE_GLOOMY = new Colour(0x990033);
+    public static final Colour ROSE_DARK_3 = new Colour(0xAA0038);
+    public static final Colour ROSE_DARK_2 = new Colour(0xBB1149);
+    public static final Colour ROSE_DARK = new Colour(0xCC225A);
+    public static final Colour ROSE = new Colour(0xDD336B);
+    public static final Colour ROSE_LIGHT_1 = new Colour(0xEE447C);
+    public static final Colour ROSE_LIGHT_2 = new Colour(0xFF558D);
+    public static final Colour ROSE_PASTEL = new Colour(0xFF6699);
+    public static final Colour ROSE_PASTEL_2 = new Colour(0xFF77A4);
+
+    public static final Colour BLACK = new Colour(0x000000);
+    public static final Colour DARK_GREY_4 = new Colour(0x1C1C1C);
+    public static final Colour DARK_GREY_3 = new Colour(0x383838);
+    public static final Colour DARK_GREY_2 = new Colour(0x555555);
+    public static final Colour DARK_GREY = new Colour(0x717171);
+    public static final Colour GREY = new Colour(0x8D8D8D);
+    public static final Colour LIGHT_GREY = new Colour(0xAAAAAA);
+    public static final Colour LIGHT_GREY_2 = new Colour(0xC6C6C6);
+    public static final Colour LIGHT_GREY_3 = new Colour(0xE2E2E2);
+    public static final Colour WHITE = new Colour(0xFFFFFF);
+
+
+    private ColourPalette() {
+
+    }
+
+    public static class Colour {
+
+        public final int rgb24;
+
+        public final int red;
+        public final int green;
+        public final int blue;
+
+        public final float red_float;
+        public final float green_float;
+        public final float blue_float;
+
+        private Colour(int rgb24) {
+            this.rgb24 = rgb24;
+
+            this.red = (rgb24 >> 16) & 0xFF;
+            this.green = (rgb24 >> 8) & 0xFF;
+            this.blue = rgb24 & 0xFF;
+
+            this.red_float = ((float) red) / 255;
+            this.green_float = ((float) green) / 255;
+            this.blue_float = ((float) blue) / 255;
+        }
+
+    }
+
+}

--- a/src/main/java/de/blazemcworld/fireflow/messages/Messages.java
+++ b/src/main/java/de/blazemcworld/fireflow/messages/Messages.java
@@ -1,0 +1,166 @@
+package de.blazemcworld.fireflow.messages;
+
+import de.blazemcworld.fireflow.FireFlow;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.platform.modcommon.MinecraftServerAudiences;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Messages {
+
+    private Messages() {
+
+    }
+
+    /**
+     * Used for messages conveying information that do not fit into other categories.
+     */
+    public static final Type INFO = new SimpleMessageType(
+            ColourPalette.LIGHT_GREY_2.rgb24,
+            ColourPalette.CORNFLOWER_PASTEL.rgb24,
+            "ℹ"
+    );
+
+    /**
+     * Used to notify the user of a successful action.
+     */
+    public static final Type SUCCESS = new SimpleMessageType(
+            ColourPalette.LIGHT_GREY_2.rgb24,
+            ColourPalette.MINT_PASTEL.rgb24,
+            "✔"
+    );
+
+    /**
+     * Used to notify the user of an error.
+     */
+    public static final Type ERROR = new SoundingMessageType(
+            ColourPalette.ROSE_PASTEL_2.rgb24,
+            ColourPalette.ROSE_DARK.rgb24,
+            "❌",
+            Sound.sound()
+                    .type(Key.key("item.mace.smash_air"))
+                    .volume(0.25f)
+                    .source(Sound.Source.MASTER)
+                    .build()
+    );
+
+    /**
+     * Used to provide additional context to previous messages.
+     */
+    public static final Type FOLLOWUP = new SimpleMessageType(
+            ColourPalette.LIGHT_GREY_2.rgb24,
+            ColourPalette.LIME_PASTEL.rgb24,
+            "→"
+    );
+
+
+    /**
+     * Escapes minimessage tags in the given message
+     * @param input The message
+     * @param type The type, if null use default minimessage, this may miss some tags
+     * @return The escaped message
+     */
+    public static String escapeMiniMessage(@NotNull String input, @Nullable Type type) {
+        MiniMessage mm = type == null ? MiniMessage.miniMessage() : type.buildMiniMessage(MiniMessage.builder());
+        return mm.escapeTags(input);
+    }
+
+    /**
+     * Styles a message as the given type. Most types provide a &lt;default&gt; tag that sets the colour to the default.
+     * @param message The message, MiniMessage.
+     * @param type The type to style as.
+     * @return The styled message.
+     */
+    public static Text styleMessage(@NotNull String message, @NotNull Type type) {
+        MiniMessage mm = type.buildMiniMessage(MiniMessage.builder());
+        String tag = type.providesDefaultTag() ? "<default>" : "";
+        Text deserialized = MinecraftServerAudiences.of(FireFlow.server).asNative(mm.deserialize(tag+message));
+        return type.addDecorations(deserialized);
+    }
+
+    /**
+     * Sends a message of the given type to a given audience. Most types provide a &lt;default&gt; tag that sets the colour to the default.
+     * @param message The message, MiniMessage.
+     * @param type The type to style as.
+     * @param audience The audience to send to.
+     */
+    public static void sendMessage(@NotNull String message, @NotNull Type type, @NotNull Audience audience) {
+        Text styled = styleMessage(message, type);
+        audience.sendMessage(MinecraftServerAudiences.of(FireFlow.server).asAdventure(styled));
+        type.audienceEffects(audience);
+    }
+
+
+
+    public interface Type {
+
+        Text addDecorations(Text text);
+
+        int getColour();
+
+        default MiniMessage buildMiniMessage(MiniMessage.Builder builder) {
+            return builder.tags(
+                    TagResolver.builder()
+                            .resolver(TagResolver.standard())
+                            .tag("default", Tag.styling(style -> style.color(TextColor.color(getColour()))))
+                            .build()
+            ).build();
+        }
+
+        default boolean providesDefaultTag() {
+            return true;
+        }
+
+        default void audienceEffects(Audience audience) {
+
+        }
+
+    }
+
+    private static class SimpleMessageType implements Type {
+
+        private final int defaultColour;
+        private final MutableText cachedIcon;
+
+        public SimpleMessageType(int defaultColour, int iconColour, String icon) {
+            this.defaultColour = defaultColour;
+            this.cachedIcon = Text.literal(icon+" ").withColor(iconColour);
+        }
+
+        @Override
+        public Text addDecorations(Text text) {
+            return cachedIcon.copy().append(text);
+        }
+
+        @Override
+        public int getColour() {
+            return defaultColour;
+        }
+
+    }
+
+    private static class SoundingMessageType extends SimpleMessageType {
+
+        private final Sound sound;
+
+        public SoundingMessageType(int defaultColour, int iconColour, String icon, Sound sound) {
+            super(defaultColour, iconColour, icon);
+            this.sound = sound;
+        }
+
+        @Override
+        public void audienceEffects(Audience audience) {
+            super.audienceEffects(audience);
+            audience.playSound(sound);
+        }
+    }
+
+}

--- a/src/main/java/de/blazemcworld/fireflow/messages/Messages.java
+++ b/src/main/java/de/blazemcworld/fireflow/messages/Messages.java
@@ -14,6 +14,8 @@ import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Set;
+
 public class Messages {
 
     private Messages() {
@@ -45,11 +47,13 @@ public class Messages {
             ColourPalette.ROSE_PASTEL_2.rgb24,
             ColourPalette.ROSE_DARK.rgb24,
             "❌",
-            Sound.sound()
-                    .type(Key.key("item.mace.smash_air"))
-                    .volume(0.25f)
-                    .source(Sound.Source.MASTER)
-                    .build()
+            Set.of(
+                    Sound.sound()
+                            .type(Key.key("item.mace.smash_air"))
+                            .volume(0.25f)
+                            .source(Sound.Source.MASTER)
+                            .build()
+            )
     );
 
     /**
@@ -59,6 +63,29 @@ public class Messages {
             ColourPalette.LIGHT_GREY_2.rgb24,
             ColourPalette.LIME_PASTEL.rgb24,
             "→"
+    );
+
+    /**
+     * Used to notify the user of an action that may require their intervention.
+     */
+    public static final Type NOTIFY = new SoundingMessageType(
+            ColourPalette.LIGHT_GREY_2.rgb24,
+            ColourPalette.MUSTARD_PASTEL.rgb24,
+            "\uD83D\uDD14",
+            Set.of(
+                    Sound.sound()
+                            .type(Key.key("entity.experience_orb.pickup"))
+                            .volume(1.0f)
+                            .pitch(2.0f)
+                            .source(Sound.Source.MASTER)
+                            .build(),
+                    Sound.sound()
+                            .type(Key.key("minecraft:block.bell.use"))
+                            .volume(0.5f)
+                            .pitch(2.0f)
+                            .source(Sound.Source.MASTER)
+                            .build()
+            )
     );
 
 
@@ -149,17 +176,18 @@ public class Messages {
 
     private static class SoundingMessageType extends SimpleMessageType {
 
-        private final Sound sound;
+        private final Set<Sound> sounds;
 
-        public SoundingMessageType(int defaultColour, int iconColour, String icon, Sound sound) {
+        public SoundingMessageType(int defaultColour, int iconColour, String icon, Set<Sound> sounds) {
             super(defaultColour, iconColour, icon);
-            this.sound = sound;
+            this.sounds = sounds;
         }
 
         @Override
         public void audienceEffects(Audience audience) {
             super.audienceEffects(audience);
-            audience.playSound(sound);
+            for (Sound sound : sounds)
+                audience.playSound(sound);
         }
     }
 

--- a/src/main/java/de/blazemcworld/fireflow/space/Lobby.java
+++ b/src/main/java/de/blazemcworld/fireflow/space/Lobby.java
@@ -3,6 +3,7 @@ package de.blazemcworld.fireflow.space;
 import de.blazemcworld.fireflow.FireFlow;
 import de.blazemcworld.fireflow.inventory.ActiveSpacesMenu;
 import de.blazemcworld.fireflow.inventory.MySpacesMenu;
+import de.blazemcworld.fireflow.messages.ColourPalette;
 import de.blazemcworld.fireflow.util.WorldUtil;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.LoreComponent;
@@ -45,7 +46,7 @@ public class Lobby {
 
     private static ItemStack mySpacesItem() {
         ItemStack item = new ItemStack(Items.ENCHANTED_BOOK);
-        item.set(DataComponentTypes.ITEM_NAME, Text.literal("My Spaces").formatted(Formatting.LIGHT_PURPLE));
+        item.set(DataComponentTypes.ITEM_NAME, Text.literal("My Spaces").withColor(ColourPalette.ROSE_LIGHT_2.rgb24));
         item.set(DataComponentTypes.LORE, new LoreComponent(List.of(
                 Text.literal("Manage your spaces").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.GRAY)),
                 Text.literal("using this item.").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.GRAY))
@@ -55,7 +56,7 @@ public class Lobby {
 
     private static ItemStack activeSpacesItem() {
         ItemStack item = new ItemStack(Items.BLAZE_POWDER);
-        item.set(DataComponentTypes.ITEM_NAME, Text.literal("Active Spaces").formatted(Formatting.GREEN));
+        item.set(DataComponentTypes.ITEM_NAME, Text.literal("Active Spaces").withColor(ColourPalette.LIME_LIGHT_2.rgb24));
         item.set(DataComponentTypes.LORE, new LoreComponent(List.of(
                 Text.literal("View currently played on").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.GRAY)),
                 Text.literal("spaces using this item.").setStyle(Style.EMPTY.withItalic(false).withColor(Formatting.GRAY))


### PR DESCRIPTION
The messages now look like:
![image](https://github.com/user-attachments/assets/39b9bdd2-4dc9-4328-86f6-eb55139c30b3)

The API can be used as so:
```java
Messages.sendMessage(
    "<white>" + approver.getGameProfile().getName() + "<default> authorized a web editor request!",
    Messages.INFO, player
);
```
It currently uses the Adventure API and MiniMessage but I am ok with changing this to use the vanilla Text API if required.


The current message types consist of:
- `INFO` - Used for messages conveying information that do not fit into other categories.
- `SUCCESS` - Used to notify the user of a successful action.
- `ERROR` - Used to notify the user of an error.
- `FOLLOWUP` - Used to provide additional context to previous messages.
- `NOTIFY` - Used to notify the user of an action that may require their intervention.
These are static final fields on the Messages class.

The `ERROR` and `NOTIFY` types play sound effects when sent to a player, i'm not too sure of the best way to show this in the PR.